### PR TITLE
Improve speed of EC-Earth processing

### DIFF
--- a/bin/run_force_fix.py
+++ b/bin/run_force_fix.py
@@ -13,6 +13,8 @@ import sys
 import traceback
 import warnings
 
+import dask
+
 import pre_proc
 from pre_proc import EsgfSubmission
 from pre_proc.common import list_files
@@ -51,6 +53,9 @@ def main(args):
     """
     Main entry point
     """
+    # Assume that this will be run with one CPU allocated
+    dask.config.set(scheduler='synchronous')
+
     logger.debug('Database directory is {}'.
                  format(os.environ['DATABASE_DIR']))
 

--- a/bin/run_force_fix.sh
+++ b/bin/run_force_fix.sh
@@ -6,6 +6,13 @@ INSTALL_DIR=/home/users/jseddon/primavera/pre-proc
 CONDA_DIR=/home/users/jseddon/software/miniconda3/bin
 CONDA_ENV_DIR=/home/users/jseddon/software/miniconda3/envs/py3-6/bin
 
+# Force NumPy not to parallelise
+export OMP_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export VECLIB_MAXIMUM_THREADS=1
+export NUMEXPR_NUM_THREADS=1
+
 export PATH=$CONDA_DIR:$PATH
 . activate py3-6
 export DJANGO_SETTINGS_MODULE=pre_proc_site.settings

--- a/bin/run_force_fix.sh
+++ b/bin/run_force_fix.sh
@@ -4,7 +4,7 @@
 # variables.
 INSTALL_DIR=/home/users/jseddon/primavera/pre-proc
 CONDA_DIR=/home/users/jseddon/software/miniconda3/bin
-CONDA_ENV_DIR=/home/users/jseddon/software/miniconda3/envs/py3-6/bin
+CONDA_ENV_DIR=/home/users/jseddon/software/miniconda3/envs/py3-6_iris2-3/bin
 
 # Force NumPy not to parallelise
 export OMP_NUM_THREADS=1
@@ -14,7 +14,7 @@ export VECLIB_MAXIMUM_THREADS=1
 export NUMEXPR_NUM_THREADS=1
 
 export PATH=$CONDA_DIR:$PATH
-. activate py3-6
+. activate py3-6_iris2-3
 export DJANGO_SETTINGS_MODULE=pre_proc_site.settings
 export PYTHONPATH=$INSTALL_DIR:$INSTALL_DIR/HighResMIP-fix:$INSTALL_DIR/cmor-fixer
 

--- a/bin/run_pre_proc.py
+++ b/bin/run_pre_proc.py
@@ -14,6 +14,8 @@ import sys
 import traceback
 import warnings
 
+import dask
+
 from pre_proc import EsgfSubmission
 from pre_proc.common import list_files
 
@@ -49,6 +51,9 @@ def main(args):
     """
     Main entry point
     """
+    # Assume that this will be run with one CPU allocated
+    dask.config.set(scheduler='synchronous')
+
     logger.debug('Database directory is {}'.
                  format(os.environ['DATABASE_DIR']))
 

--- a/bin/run_pre_proc.sh
+++ b/bin/run_pre_proc.sh
@@ -6,6 +6,13 @@ INSTALL_DIR=/home/users/jseddon/primavera/pre-proc
 CONDA_DIR=/home/users/jseddon/software/miniconda3/bin
 CONDA_ENV_DIR=/home/users/jseddon/software/miniconda3/envs/py3-6/bin
 
+# Force NumPy not to parallelise
+export OMP_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export VECLIB_MAXIMUM_THREADS=1
+export NUMEXPR_NUM_THREADS=1
+
 export PATH=$CONDA_DIR:$PATH
 . activate py3-6
 export DJANGO_SETTINGS_MODULE=pre_proc_site.settings

--- a/bin/run_pre_proc.sh
+++ b/bin/run_pre_proc.sh
@@ -4,7 +4,7 @@
 # variables.
 INSTALL_DIR=/home/users/jseddon/primavera/pre-proc
 CONDA_DIR=/home/users/jseddon/software/miniconda3/bin
-CONDA_ENV_DIR=/home/users/jseddon/software/miniconda3/envs/py3-6/bin
+CONDA_ENV_DIR=/home/users/jseddon/software/miniconda3/envs/py3-6_iris2-3/bin
 
 # Force NumPy not to parallelise
 export OMP_NUM_THREADS=1
@@ -14,7 +14,7 @@ export VECLIB_MAXIMUM_THREADS=1
 export NUMEXPR_NUM_THREADS=1
 
 export PATH=$CONDA_DIR:$PATH
-. activate py3-6
+. activate py3-6_iris2-3
 export DJANGO_SETTINGS_MODULE=pre_proc_site.settings
 export PYTHONPATH=$INSTALL_DIR:$INSTALL_DIR/HighResMIP-fix:$INSTALL_DIR/cmor-fixer
 

--- a/bin/run_single_file.py
+++ b/bin/run_single_file.py
@@ -9,6 +9,8 @@ import logging.config
 import os
 import sys
 
+import dask
+
 from pre_proc import EsgfSubmission
 from pre_proc.exceptions import PreProcError
 
@@ -42,6 +44,9 @@ def main(args):
     """
     Main entry point
     """
+    # Assume that this will be run with one CPU allocated
+    dask.config.set(scheduler='synchronous')
+
     logger.debug('Database directory is {}'.
                  format(os.environ['DATABASE_DIR']))
 

--- a/bin/run_single_file.sh
+++ b/bin/run_single_file.sh
@@ -6,6 +6,13 @@ INSTALL_DIR=/home/users/jseddon/primavera/pre-proc
 CONDA_DIR=/home/users/jseddon/software/miniconda3/bin
 CONDA_ENV_DIR=/home/users/jseddon/software/miniconda3/envs/py3-6/bin
 
+# Force NumPy not to parallelise
+export OMP_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export VECLIB_MAXIMUM_THREADS=1
+export NUMEXPR_NUM_THREADS=1
+
 export PATH=$CONDA_DIR:$PATH
 . activate py3-6
 export DJANGO_SETTINGS_MODULE=pre_proc_site.settings

--- a/bin/run_single_file.sh
+++ b/bin/run_single_file.sh
@@ -4,7 +4,7 @@
 # variables.
 INSTALL_DIR=/home/users/jseddon/primavera/pre-proc
 CONDA_DIR=/home/users/jseddon/software/miniconda3/bin
-CONDA_ENV_DIR=/home/users/jseddon/software/miniconda3/envs/py3-6/bin
+CONDA_ENV_DIR=/home/users/jseddon/software/miniconda3/envs/py3-6_iris2-3/bin
 
 # Force NumPy not to parallelise
 export OMP_NUM_THREADS=1
@@ -14,7 +14,7 @@ export VECLIB_MAXIMUM_THREADS=1
 export NUMEXPR_NUM_THREADS=1
 
 export PATH=$CONDA_DIR:$PATH
-. activate py3-6
+. activate py3-6_iris2-3
 export DJANGO_SETTINGS_MODULE=pre_proc_site.settings
 export PYTHONPATH=$INSTALL_DIR:$INSTALL_DIR/HighResMIP-fix:$INSTALL_DIR/cmor-fixer
 


### PR DESCRIPTION
* Use Iris 2.3
* Use a single NumPy thread
* Let Dask use an appropriate scheduler for one core